### PR TITLE
Replaces rake webpack:compile, with repack:compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Next you will need to set up a post build hook to bundle Webpack. Include the be
 
 Lastly, ensure that all Babel related modules are listed as dependencies and not dev dependencies in `package.json`. At this point, you should be able to push to Heroku.
 
-An alternative to adding the post build hook to `package.json` is to add `rake webpack:compile` to your deployment. It serves a similar purpose as Sprockets' `assets:precompile` task. If you're using Webpack and Sprockets (as we are at Marketplacer) you'll need to run both tasks - but it doesn't matter which order they're run in.
+An alternative to adding the post build hook to `package.json` is to add `rake repack:compile` to your deployment. It serves a similar purpose as Sprockets' `assets:precompile` task. If you're using Webpack and Sprockets (as we are at Marketplacer) you'll need to run both tasks - but it doesn't matter which order they're run in.
 
 If you're using `[chunkhash]` in your build asset filenames (which you should be, if you want to cache them in production), you'll need to persist built assets between deployments. Consider in-flight requests at the time of deployment: they'll receive paths based on the old `manifest.json`, not the new one.
 

--- a/lib/repack/railtie.rb
+++ b/lib/repack/railtie.rb
@@ -12,14 +12,14 @@ module Repack
     end
 
     config.repack = ActiveSupport::OrderedOptions.new
-    config.repack.config_file = 'config/repack.config.js'
-    config.repack.binary = 'node_modules/.bin/repack'
+    config.repack.config_file = 'config/webpack.config.js'
+    config.repack.binary = 'node_modules/.bin/webpack'
 
     config.repack.dev_server = ActiveSupport::OrderedOptions.new
     config.repack.dev_server.host = 'localhost'
     config.repack.dev_server.port = 3808
     config.repack.dev_server.https = false # note - this will use OpenSSL::SSL::VERIFY_NONE
-    config.repack.dev_server.binary = 'node_modules/.bin/repack-dev-server'
+    config.repack.dev_server.binary = 'node_modules/.bin/webpack-dev-server'
     config.repack.dev_server.enabled = !::Rails.env.production?
 
     config.repack.output_dir = "public/client"
@@ -27,7 +27,7 @@ module Repack
     config.repack.manifest_filename = "manifest.json"
 
     rake_tasks do
-      load "tasks/webpack.rake"
+      load "tasks/repack.rake"
     end
   end
 end

--- a/lib/tasks/repack.rake
+++ b/lib/tasks/repack.rake
@@ -1,9 +1,9 @@
-namespace :webpack do
+namespace :repack do
   desc "Compile webpack bundles"
   task compile: :environment do
     ENV["TARGET"] = 'production'
-    webpack_bin = ::Rails.root.join(::Rails.configuration.webpack.binary)
-    config_file = ::Rails.root.join(::Rails.configuration.webpack.config_file)
+    webpack_bin = ::Rails.root.join(::Rails.configuration.repack.binary)
+    config_file = ::Rails.root.join(::Rails.configuration.repack.config_file)
 
     unless File.exist?(webpack_bin)
       raise "Can't find our webpack executable at #{webpack_bin} - have you run `npm install`?"


### PR DESCRIPTION
The currently existing `rake webpack:compile` breaks on a few lines that appear to have been accidentally switched from `webpack` to `repack`.

References to js have been switched back to `webpack`.
Task has also been renamed to better reflect the Rails side namespacing.